### PR TITLE
Plugin does not exit in failure if OpenAI API key is missing

### DIFF
--- a/hooks/post-command
+++ b/hooks/post-command
@@ -10,40 +10,45 @@ echo "--- :robot_face: ChatGPT Analyzer Plugin"
 # Validate required tools
 validate_required_tools || exit 1
 
-# Get required plugin configurations
-echo "Retrieving OpenAI API Key ..."
+# Get required plugin configurations 
 # Read plugin configuration for OpenAI API Key
 API_KEY=$(get_openai_api_key)
 if [ -z "${API_KEY}" ]; then
-  log_error 'Missing OpenAI API Key. Please set the API_KEY in your plugin configuration.'
-  exit 1
-fi   
-
-echo "Retrieving other plugin configurations ..."
-# Load Plugin configuration
-BUILDKITE_API_TOKEN=$(get_bk_api_token) 
-MODEL=$(plugin_read_config MODEL "gpt-5-nano")
-ANALYSIS_LEVEL=$(plugin_read_config ANALYSIS_LEVEL "step")
-CUSTOM_PROMPT=$(plugin_read_config CUSTOM_PROMPT "")
-COMPARE_BUILDS=$(plugin_read_config COMPARE_BUILDS "false")
-COMPARISON_RANGE=$(plugin_read_config BUILD_COMPARISON_RANGE "5")
-
-echo "Using Model: ${MODEL}"
-echo "Analysis Level: ${ANALYSIS_LEVEL}"
-if [ -n "${CUSTOM_PROMPT}" ]; then
-  echo "Using Custom Prompt: ${CUSTOM_PROMPT}"
-fi
-
-if [ "${COMPARE_BUILDS}" = "true" ]; then
-  echo "Build Comparison: ENABLED. Comparing with last ${COMPARISON_RANGE} builds."
+  log_warning 'Missing OpenAI API Key. Skipping ChatGPT Analysis. ❌'
+  echo -e "ChatGPT Analyzer Plugin: Missing OpenAI API Key. Skipping analysis." | buildkite-agent annotate  --style "warning" --context "chatgpt-analysis-${BUILDKITE_JOB_ID}" 
+  exit 0
 else
-  echo "Build Comparison: Disabled."
+  echo "OpenAI API Key found. ✅"
+
+  # Load Plugin configuration
+  BUILDKITE_API_TOKEN=$(get_bk_api_token) 
+  MODEL=$(plugin_read_config MODEL "gpt-5-nano")
+  ANALYSIS_LEVEL=$(plugin_read_config ANALYSIS_LEVEL "step")
+  CUSTOM_PROMPT=$(plugin_read_config CUSTOM_PROMPT "")
+  COMPARE_BUILDS=$(plugin_read_config COMPARE_BUILDS "false")
+  COMPARISON_RANGE=$(plugin_read_config BUILD_COMPARISON_RANGE "5")
+
+  echo "Loading Plugin with configurations:"
+  echo "-----------------------------------"
+  echo "  Using Model: ${MODEL}"
+  echo "  Analysis Level: ${ANALYSIS_LEVEL}"
+  if [ -n "${CUSTOM_PROMPT}" ]; then
+    echo "  Using Custom Prompt: ${CUSTOM_PROMPT}"
+  fi
+
+  if [ "${COMPARE_BUILDS}" = "true" ]; then
+    echo "  Build Comparison: ENABLED. Comparing with last ${COMPARISON_RANGE} builds."
+  else
+    echo "  Build Comparison: Disabled."
+  fi
+  echo "-----------------------------------"
+
+  # Summarize build information 
+  BUILD_SUMMARY=$(get_build_summary "${BUILDKITE_API_TOKEN}" "${ANALYSIS_LEVEL}" "${COMPARE_BUILDS}" "${COMPARISON_RANGE}")
+
+  echo "Build Summary generated. ✅" 
+  send_prompt "${API_KEY}" "${BUILD_SUMMARY}" "${MODEL}" "${CUSTOM_PROMPT}" "${ANALYSIS_LEVEL}"
+
+  echo "ChatGPT Analysis complete. Check the annotations for details. ✅"
+  exit 0
 fi
-
-# Summarize build information 
-BUILD_SUMMARY=$(get_build_summary "${BUILDKITE_API_TOKEN}" "${ANALYSIS_LEVEL}" "${COMPARE_BUILDS}" "${COMPARISON_RANGE}")
-
-log_success "Done generating summary for this ${ANALYSIS_LEVEL}." 
-send_prompt "${API_KEY}" "${BUILD_SUMMARY}" "${MODEL}" "${CUSTOM_PROMPT}" "${ANALYSIS_LEVEL}"
-
-echo "~~~ Done."

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -14,8 +14,8 @@ validate_required_tools || exit 1
 # Read plugin configuration for OpenAI API Key
 API_KEY=$(get_openai_api_key)
 if [ -z "${API_KEY}" ]; then
-  log_warning 'Missing OpenAI API Key. Skipping ChatGPT Analysis. ❌'
-  echo -e "ChatGPT Analyzer Plugin: Missing OpenAI API Key. Skipping analysis." | buildkite-agent annotate  --style "warning" --context "chatgpt-analysis-${BUILDKITE_JOB_ID}" 
+  log_warning 'OpenAI API Key not found. Skipping ChatGPT Analysis. ❌'
+  echo -e "ChatGPT Analyzer Plugin: Skipping analysis - OpenAI API Key not found." | buildkite-agent annotate  --style "warning" --context "chatgpt-analysis-${BUILDKITE_JOB_ID}" 
   exit 0
 else
   echo "OpenAI API Key found. ✅"

--- a/lib/plugin.bash
+++ b/lib/plugin.bash
@@ -608,17 +608,21 @@ function send_prompt() {
         else
           buildkite-agent annotate --style "info" --context "chatgpt-analysis-${BUILDKITE_JOB_ID}"  < "${annotation_file}"
         fi
-        echo "✅ Annotation created successfully."
+        echo "Annotation created successfully. ✅"
+        echo "ChatGPT Analysis complete. ✅"
         rm -f "${annotation_file}"
       else
         echo -e "ChatGPT analysis in Job ${BUILDKITE_JOB_ID} (${BUILDKITE_LABEL}) failed to generate an annotation file." | buildkite-agent annotate --style "error" --context "chatgpt-analysis-${BUILDKITE_JOB_ID}"
+        echo "ChatGPT Analysis failed. Annotation file generation failed. ❌"
       fi
     else
       echo -e "ChatGPT analysis in Job ${BUILDKITE_JOB_ID} (${BUILDKITE_LABEL}) failed to generate content." | buildkite-agent annotate --style "error" --context "chatgpt-analysis-${BUILDKITE_JOB_ID}"
+      echo "ChatGPT Analysis failed. API content response does not look valid. ❌"
     fi
   else
-    echo "ChatGPT analysis failed. Please check the logs for more details."
-  fi 
+    echo -e "ChatGPT analysis in Job ${BUILDKITE_JOB_ID} (${BUILDKITE_LABEL}) failed to send summary to ChatGPT for analysis. Check logs for details." | buildkite-agent annotate --style "error" --context "chatgpt-analysis-${BUILDKITE_JOB_ID}"
+    echo "ChatGPT Analysis failed. No valid response received from OpenAI API. ❌"
+  fi
 
   return 0
 }

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -4,6 +4,7 @@ setup() {
   load "${BATS_PLUGIN_PATH}/load.bash"
 
   export BUILDKITE_PLUGIN_CHATGPT_ANALYZER_API_KEY='test0aou'
+  export BUILDKITE_PLUGIN_CHATGPT_ANALYZER_BUILDKITE_API_TOKEN='test-bk-token'
   export BUILDKITE_ORGANIZATION_SLUG="testorg"
   export BUILDKITE_PIPELINE_SLUG="test-pipeline"
   export BUILDKITE_BUILD_NUMBER="1"
@@ -37,7 +38,8 @@ teardown() {
 
   run "$PWD"/hooks/post-command
 
-  assert_failure
+  assert_success
+  assert_output --partial 'ChatGPT Analyzer Plugin'
   assert_output --partial 'Missing OpenAI API Key' 
 }
 
@@ -46,10 +48,14 @@ teardown() {
 
   assert_success
   assert_output --partial 'ChatGPT Analyzer Plugin'
-  assert_output --partial 'Retrieving OpenAI API Key ...'
+  assert_output --partial 'Loading Plugin with configurations:'
+  assert_output --partial '-----------------------------------'
   assert_output --partial 'Using Model: gpt-5-nano'
   assert_output --partial 'Analysis Level: step' 
-  assert_output --partial 'Done generating summary for this step'
+  assert_output --partial 'Build Comparison: Disabled'
+  assert_output --partial '-----------------------------------'
+  assert_output --partial 'Build Summary generated'
+  assert_output --partial 'ChatGPT Analysis complete'
 }
 
 @test "Specify new values for Optional Configuration" {
@@ -63,17 +69,19 @@ teardown() {
 
   assert_success
   assert_output --partial 'ChatGPT Analyzer Plugin'
-  assert_output --partial 'Retrieving OpenAI API Key ...'
+  assert_output --partial 'Loading Plugin with configurations:'
+  assert_output --partial '-----------------------------------'
   assert_output --partial 'Using Model: gpt-5'
   assert_output --partial 'Analysis Level: build'
   assert_output --partial 'Using Custom Prompt: Custom prompt. This is an additional Custom Prompt '
   assert_output --partial 'Build Comparison: ENABLED. Comparing with last 10 builds.'
-  assert_output --partial 'Done generating summary for this build'
+  assert_output --partial '-----------------------------------'
+  assert_output --partial 'Build Summary generated'
+  assert_output --partial 'ChatGPT Analysis complete'
 }
 
-
 @test "Plugin runs with environment variable data" {
-  export BUILDKITE_PLUGIN_YOUR_CHATGPT_ANALYSER_BUILDKITE_API_TOKEN='test_secret' 
+  unset BUILDKITE_PLUGIN_CHATGPT_ANALYZER_BUILDKITE_API_TOKEN
   export BUILDKITE_SOURCE='ui' 
   export BUILDKITE_COMMAND='echo "Hello, World!"'
   export BUILDKITE_COMMAND_EXIT_STATUS='0'
@@ -82,8 +90,8 @@ teardown() {
 
   assert_success 
   assert_output --partial 'ChatGPT Analyzer Plugin'
-  assert_output --partial 'Done generating summary for this step' 
-  assert_output --partial 'ChatGPT Analysis Result'
+  assert_output --partial 'Build Summary generated'
+  assert_output --partial 'ChatGPT Analysis complete'
 }
 
 @test "Plugin handles invalid API Token" {
@@ -95,10 +103,10 @@ teardown() {
   run "$PWD"/hooks/post-command
 
   assert_success 
-  assert_output --partial 'ChatGPT Analyzer Plugin'
-  assert_output --partial 'Done generating summary for this step' 
-  assert_output --partial 'ChatGPT Analysis Result'
-  assert_output --partial 'No response received from OpenAI API'
+  assert_output --partial 'ChatGPT Analyzer Plugin' 
+  assert_output --partial 'Build Summary generated'
+  assert_output --partial 'No valid response received from OpenAI API'
+  assert_output --partial 'ChatGPT Analysis complete'
 }
 
 

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -40,7 +40,7 @@ teardown() {
 
   assert_success
   assert_output --partial 'ChatGPT Analyzer Plugin'
-  assert_output --partial 'Missing OpenAI API Key' 
+  assert_output --partial 'OpenAI API Key not found' 
 }
 
 @test "Minimal Configuration" {


### PR DESCRIPTION
- Plugin should just warn user if it failed rather than causing the build to fail.
- Improved logs generated by the post-command hook 