### PR TITLE
Fix jq error when argument list is too long

### DIFF
--- a/hooks/post-command
+++ b/hooks/post-command
@@ -47,7 +47,7 @@ else
   BUILD_SUMMARY=$(get_build_summary "${BUILDKITE_API_TOKEN}" "${ANALYSIS_LEVEL}" "${COMPARE_BUILDS}" "${COMPARISON_RANGE}")
 
   echo "Build Summary generated. ✅" 
-  analyse_build "${API_KEY}" "${BUILD_SUMMARY}" "${MODEL}" "${CUSTOM_PROMPT}" "${ANALYSIS_LEVEL}"
+  analyse_build "${API_KEY}" "${BUILD_SUMMARY}" "${MODEL}" "${CUSTOM_PROMPT}" "${ANALYSIS_LEVEL}" "${COMPARE_BUILDS}"
 
   echo "ChatGPT Analysis complete. Check the annotations for details. ✅"
   exit 0

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -15,7 +15,7 @@ validate_required_tools || exit 1
 API_KEY=$(get_openai_api_key)
 if [ -z "${API_KEY}" ]; then
   log_warning 'OpenAI API Key not found. Skipping ChatGPT Analysis. ❌'
-  echo -e "ChatGPT Analyzer Plugin: Skipping analysis - OpenAI API Key not found." | buildkite-agent annotate  --style "warning" --context "chatgpt-analysis-${BUILDKITE_JOB_ID}" 
+  echo -e "ChatGPT Analyzer: Analysis in Job ${BUILDKITE_JOB_ID} (${BUILDKITE_LABEL}) was skipped - OpenAI API Key not found." | buildkite-agent annotate  --style "warning" --context "chatgpt-analysis-${BUILDKITE_JOB_ID}" 
   exit 0
 else
   echo "OpenAI API Key found. ✅"

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -47,7 +47,7 @@ else
   BUILD_SUMMARY=$(get_build_summary "${BUILDKITE_API_TOKEN}" "${ANALYSIS_LEVEL}" "${COMPARE_BUILDS}" "${COMPARISON_RANGE}")
 
   echo "Build Summary generated. ✅" 
-  send_prompt "${API_KEY}" "${BUILD_SUMMARY}" "${MODEL}" "${CUSTOM_PROMPT}" "${ANALYSIS_LEVEL}"
+  analyse_build "${API_KEY}" "${BUILD_SUMMARY}" "${MODEL}" "${CUSTOM_PROMPT}" "${ANALYSIS_LEVEL}"
 
   echo "ChatGPT Analysis complete. Check the annotations for details. ✅"
   exit 0

--- a/lib/plugin.bash
+++ b/lib/plugin.bash
@@ -685,13 +685,11 @@ function build_system_prompt() {
         if [ "${compare_builds}" = "true" ]; then
           system_prompt="${system_prompt} 
 3. **Job's Run Time Comparison**: Analyze the job's run time trends compared to recent builds. Identify patterns or anomalies in job duration."
+        fi
       fi
-
-
   fi
-
   echo "${system_prompt}
-  
+
 If no errors are found, just confirm the build succeeded.
 Do not include speculative or unrelated information."
 

--- a/lib/plugin.bash
+++ b/lib/plugin.bash
@@ -682,6 +682,9 @@ function build_system_prompt() {
         system_prompt="${system_prompt} Focus on the following aspects:
 1. **Analysis**: What happened in this job? $([ "${BUILDKITE_COMMAND_EXIT_STATUS:-0}" -ne 0 ] && echo "Why did this job fail?" || echo "Any notable issues or warnings in this job?")
 2. **Key Points**: Important information in this job."
+        if [ "${compare_builds}" = "true" ]; then
+          system_prompt="${system_prompt} 
+3. **Job's Run Time Comparison**: Analyze the job's run time trends compared to recent builds. Identify patterns or anomalies in job duration."
       fi
 
 

--- a/lib/plugin.bash
+++ b/lib/plugin.bash
@@ -667,7 +667,7 @@ function build_system_prompt() {
   system_prompt="You are an expert software engineer and DevOps specialist specialising in Buildkite."
    
   if [ -n "${custom_prompt}" ]; then
-      system_prompt="${system_prompt} ${custom_prompt}"
+      system_prompt="${custom_prompt}"
   else 
       system_prompt="${system_prompt} Please provide a detailed analysis of the ${analysis_level} information provided." 
       if [ "${analysis_level}" = "build" ]; then

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -8,11 +8,15 @@ setup() {
   export BUILDKITE_ORGANIZATION_SLUG="testorg"
   export BUILDKITE_PIPELINE_SLUG="test-pipeline"
   export BUILDKITE_BUILD_NUMBER="1"
-  export BUILDKITE_BUILD_ID="123-build-id"
+  export BUILDKITE_BUILD_ID="123-test-build-id"
   export BUILDKITE_JOB_ID="456-job-id"
   export BUILDKITE_SOURCE="ui"
   export BUILDKITE_PULL_REQUEST="false"
   export BUILDKITE_LABEL="Test Job 456"
+
+  # create a mock response file for curl to use
+  mkdir -p /tmp
+  printf '{"choices":[{"message":{"role": "assistant", "content": "Here is a practical Analysis for this Build \nMock Analysis Result"}}]}' > "/tmp/chatgpt_analyzer_response_${BUILDKITE_BUILD_ID}.json"
 
   # Mock tools with simpler stubs
   stub curl \
@@ -25,6 +29,8 @@ setup() {
 }
 
 teardown() {
+  # Remove the mock response file
+  rm -f "/tmp/chatgpt_analyzer_response_${BUILDKITE_BUILD_ID:-123-test-build-id}.json"
 
   # Only unstub if they were actually stubbed
   unstub curl || true
@@ -48,6 +54,7 @@ teardown() {
 
   assert_success
   assert_output --partial 'ChatGPT Analyzer Plugin'
+  assert_output --partial 'OpenAI API Key found'
   assert_output --partial 'Loading Plugin with configurations:'
   assert_output --partial '-----------------------------------'
   assert_output --partial 'Using Model: gpt-5-nano'


### PR DESCRIPTION
This PR addresses the issue raised here - https://github.com/buildkite-plugins/chatgpt-analyzer-buildkite-plugin/issues/10. The jq error was most likely due to the content (containing the build logs) exceeding system limits when constructing the payload to send to OpenAI. One solution to address this is to use a temporary file when building the json payload data.
